### PR TITLE
Add `PackagingTask`

### DIFF
--- a/src/py2exe_gui/Core/__init__.py
+++ b/src/py2exe_gui/Core/__init__.py
@@ -1,0 +1,3 @@
+from .packaging import Packaging
+from .packaging_task import PackagingTask
+from .validators import FilePathValidator, InterpreterValidator

--- a/src/py2exe_gui/Core/interpreter_validator.py
+++ b/src/py2exe_gui/Core/interpreter_validator.py
@@ -1,0 +1,104 @@
+import os
+import subprocess
+from pathlib import Path
+from typing import Union
+
+
+class InterpreterValidator:
+    """
+    验证给定的可执行文件是否为有效的Python解释器，并获取该解释器相关信息
+    """
+
+    def __init__(self, path: Union[str, os.PathLike[str]]) -> None:
+        """
+        :param path: 可执行文件路径
+        """
+
+        self._itp_path: Path = Path(path)
+        self._itp_validated: bool = False
+        self.validate_itp()
+
+    def validate_itp(self) -> bool:
+        """
+        :return: 解释器是否有效
+        """
+
+        if (
+            self._itp_path.exists()  # 该路径存在
+            and self._itp_path.is_file()  # 为文件
+            and self._itp_path.name.startswith("python")  # 文件名以python起始
+        ):
+            try:
+                # 尝试将该文件作为Python解释器运行
+                subprocess_args = [
+                    str(self._itp_path.resolve()),
+                    "-c",
+                    "import sys",
+                ]
+                result = subprocess.run(
+                    args=subprocess_args,
+                    timeout=300,
+                )
+                if result.returncode == 0:
+                    self._itp_validated = True
+                    return True
+                else:
+                    self._itp_validated = False
+                    return False
+            except OSError:
+                self._itp_validated = False
+                return False
+        else:
+            self._itp_validated = False
+            return False
+
+    def itp_info(self):
+        """
+        返回解释器的相关信息 \n
+        """
+
+        # FIXME 完善此方法
+        if self._itp_validated:
+            pass
+
+    def module_installed(self, module: str) -> bool:
+        """
+        验证该解释器环境中是否已安装某个模块 \n
+        :param module: 模块名，要求为import语句中使用的名称
+        :return: 未安装该模块或解释器无效时返回False
+        """
+
+        if self._itp_validated:
+            subprocess_arg_list = [
+                str(self._itp_path.resolve()),
+                "-c",
+                f"import {module}",
+            ]
+            result = subprocess.run(
+                args=subprocess_arg_list,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=300,
+            )
+            if result.returncode != 0 and b"ModuleNotFoundError" in result.stderr:
+                return False
+            else:
+                return True
+        else:
+            return False
+
+    @classmethod
+    def validate(cls, path: Union[str, os.PathLike[str]]) -> bool:
+        """
+        验证path是否指向有效的Python解释器 \n
+        :return: 是否有效
+        """
+
+        return InterpreterValidator(path).validate_itp()
+
+
+if __name__ == "__main__":
+    # print(InterpreterValidator.validate("/usr/bin/python"))
+    iv = InterpreterValidator("/usr/bin/python")
+    print(iv.module_installed("PySide6"))
+    print(iv.module_installed("black"))

--- a/src/py2exe_gui/Core/packaging_task.py
+++ b/src/py2exe_gui/Core/packaging_task.py
@@ -29,7 +29,7 @@ class PackagingTask(QtCore.QObject):
 
     def handle_option(self, option: tuple[str, str]):
         """
-        处理用户在界面选择的打包选项 \n
+        处理用户在界面选择的打包选项，进行有效性验证并保存 \n
         :param option: 选项
         """
 
@@ -39,20 +39,30 @@ class PackagingTask(QtCore.QObject):
         if arg_key == "script_path":
             script_path = Path(arg_value)
             if FilePathValidator.validate_script(script_path):
-                self.out_name = script_path.stem  # 输出名默认与脚本名相同
+                self.script_path = script_path
                 self.ready_to_pack.emit(True)
                 self.option_set.emit(option)
+                self.out_name = script_path.stem  # 输出名默认与脚本名相同
+                self.option_set.emit(("out_name", self.out_name))
             else:
                 self.ready_to_pack.emit(False)
-                self.option_error.emit("script_path")
+                self.option_error.emit(arg_key)
+            # self.option_error.emit(arg_key)  # 测试用！
+
         elif arg_key == "icon_path":
-            self.option_set.emit(option)
-        elif arg_key == "FD":
-            self.option_set.emit(option)
-        elif arg_key == "console":
-            self.option_set.emit(option)
+            icon_path = Path(arg_value)
+            if FilePathValidator.validate_icon(icon_path):
+                self.icon_path = icon_path
+                self.option_set.emit(option)
+            else:
+                self.option_error.emit(arg_key)
+            # self.option_error.emit(arg_key)  # 测试用！
+
         elif arg_key == "out_name":
             self.out_name = arg_value
+            self.option_set.emit(option)
+
+        else:
             self.option_set.emit(option)
 
     def write_to_file(self):

--- a/src/py2exe_gui/Core/packaging_task.py
+++ b/src/py2exe_gui/Core/packaging_task.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+from typing import Optional
+
+from PySide6 import QtCore
+
+from .validators import FilePathValidator, InterpreterValidator
+
+
+class PackagingTask(QtCore.QObject):
+    """
+    打包任务类，存储每个打包任务的详细信息
+    """
+
+    # 自定义信号
+    option_set = QtCore.Signal(tuple)  # 用户输入选项通过了验证，已设置为打包选项
+    option_error = QtCore.Signal()  # 用户输入选项有误，需要进一步处理
+
+    def __init__(self, parent: Optional[QtCore.QObject] = None) -> None:
+        """
+        :param parent: 父控件对象
+        """
+
+        super(PackagingTask, self).__init__(parent)
+
+        self.script_path: Optional[Path] = None
+        self.icon_path: Optional[Path] = None
+
+    def handle_option(self, option: tuple):
+        """
+        处理用户在界面选择的打包选项 \n
+        :param option: 选项
+        """
+
+        arg_key, arg_value = option
+
+        # 进行有效性验证，有效则保存并发射option_set信号，无效则发射option_error信号
+        if arg_key == "script_path":
+            self.option_set.emit(option)
+        elif arg_key == "icon_path":
+            self.option_set.emit(option)
+        elif arg_key == "FD":
+            self.option_set.emit(option)
+        elif arg_key == "console":
+            self.option_set.emit(option)
+        elif arg_key == "out_name":
+            self.option_set.emit(option)
+
+    def write_to_file(self):
+        """
+        将打包任务保存至文件
+        """
+
+        pass

--- a/src/py2exe_gui/Core/validators.py
+++ b/src/py2exe_gui/Core/validators.py
@@ -4,6 +4,26 @@ from pathlib import Path
 from typing import Union
 
 
+class FilePathValidator:
+    """
+    根据给定的路径验证文件的有效性
+    """
+
+    @classmethod
+    def validate_script(cls, script_path: Union[str, Path]) -> bool:
+        """
+        验证脚本路径是否有效 \n
+        :param script_path: 脚本路径
+        """
+
+        path = Path(script_path)
+        # TODO 完善验证方法
+        if path.exists() and path.is_file():
+            return True
+        else:
+            return False
+
+
 class InterpreterValidator:
     """
     验证给定的可执行文件是否为有效的Python解释器，并获取该解释器相关信息

--- a/src/py2exe_gui/Core/validators.py
+++ b/src/py2exe_gui/Core/validators.py
@@ -23,6 +23,20 @@ class FilePathValidator:
         else:
             return False
 
+    @classmethod
+    def validate_icon(cls, icon_path: Union[str, Path]) -> bool:
+        """
+        验证图标路径是否有效 \n
+        :param icon_path: 图标路径
+        """
+
+        path = Path(icon_path)
+        # TODO 完善验证方法
+        if path.exists() and path.is_file():
+            return True
+        else:
+            return False
+
 
 class InterpreterValidator:
     """

--- a/src/py2exe_gui/Widgets/__init__.py
+++ b/src/py2exe_gui/Widgets/__init__.py
@@ -1,0 +1,4 @@
+from .arguments_browser import ArgumentsBrowser
+from .center_widget import CenterWidget
+from .dialog_widgets import *
+from .main_window import MainWindow

--- a/src/py2exe_gui/Widgets/center_widget.py
+++ b/src/py2exe_gui/Widgets/center_widget.py
@@ -98,8 +98,7 @@ class CenterWidget(QWidget):
         self.pyinstaller_args_browser.setMaximumHeight(80)
 
         self.run_packaging_btn.setText("打包！")
-        # TODO 完成输入检查前、子进程运行时打包按钮设置为不可用
-        # self.run_packaging_btn.setEnabled(False)
+        self.run_packaging_btn.setEnabled(False)
 
     def _connect_slots(self) -> None:
         """
@@ -114,7 +113,6 @@ class CenterWidget(QWidget):
             """
 
             # TODO 验证有效性、将脚本名作为默认app名
-            # 将字符串类型的文件路径转成pathlib型的？
             self.script_path_le.setText(file_path)
             self.parent().statusBar().showMessage(f"打开脚本路径：{file_path}")
             self.option_selected.emit(("script_path", file_path))
@@ -209,3 +207,31 @@ class CenterWidget(QWidget):
         main_layout.addWidget(self.pyinstaller_args_browser)
         main_layout.addWidget(self.run_packaging_btn)
         self.setLayout(main_layout)
+
+    @QtCore.Slot(tuple)
+    def handle_option_set(self, option: tuple[str, str]) -> None:
+        """
+        处理option_set信号的槽 \n
+        :param option: 选项键值对
+        """
+
+        pass
+
+    @QtCore.Slot(str)
+    def handle_option_error(self, option: str) -> None:
+        """
+        处理option_error信号的槽 \n
+        :param option: 选项
+        """
+
+        # 清空重置该项的输入控件，等待用户重新输入
+        pass
+
+    @QtCore.Slot(bool)
+    def handle_ready_to_pack(self, ready: bool) -> None:
+        """
+        处理ready_to_pack信号的槽 \n
+        :param ready: 是否可以进行打包
+        """
+
+        self.run_packaging_btn.setEnabled(ready)

--- a/src/py2exe_gui/__main__.py
+++ b/src/py2exe_gui/__main__.py
@@ -4,6 +4,7 @@ from PySide6 import QtGui
 from PySide6.QtWidgets import QApplication
 
 from py2exe_gui.Core.packaging import Packaging
+from py2exe_gui.Core.packaging_task import PackagingTask
 from py2exe_gui.Widgets.dialog_widgets import SubProcessDlg
 from py2exe_gui.Widgets.main_window import MainWindow
 
@@ -17,13 +18,15 @@ class MainApp(MainWindow):
         super(MainApp, self).__init__(*args, **kwargs)
 
         self.packager = Packaging(self)
+        self.packaging_task = PackagingTask(self)
+        self.center_widget.option_selected.connect(self.packaging_task.handle_option)
+        self.packaging_task.option_set.connect(self.packager.set_pyinstaller_args)
 
         self.packager.args_settled.connect(
             lambda val: self.center_widget.pyinstaller_args_browser.enrich_args_text(
                 val
             )
         )
-        self.center_widget.option_selected.connect(self.packager.set_pyinstaller_args)
 
         self.subprocess_dlg = SubProcessDlg(self)
 

--- a/src/py2exe_gui/__main__.py
+++ b/src/py2exe_gui/__main__.py
@@ -17,18 +17,33 @@ class MainApp(MainWindow):
     def __init__(self, *args, **kwargs) -> None:
         super(MainApp, self).__init__(*args, **kwargs)
 
-        self.packager = Packaging(self)
         self.packaging_task = PackagingTask(self)
+        self.packager = Packaging(self)
+        self.subprocess_dlg = SubProcessDlg(self)
+
+        self._connect_signals()
+
+        self.status_bar.showMessage("就绪")
+
+    def _connect_signals(self) -> None:
+        """
+        连接各种信号与槽 \n
+        """
+
         self.center_widget.option_selected.connect(self.packaging_task.handle_option)
         self.packaging_task.option_set.connect(self.packager.set_pyinstaller_args)
+        self.packaging_task.option_set.connect(self.center_widget.handle_option_set)
+        self.packaging_task.option_error.connect(self.center_widget.handle_option_error)
+        self.packaging_task.ready_to_pack.connect(
+            self.center_widget.handle_ready_to_pack
+        )
 
+        # TODO 优化pyinstaller_args_browser的接口
         self.packager.args_settled.connect(
             lambda val: self.center_widget.pyinstaller_args_browser.enrich_args_text(
                 val
             )
         )
-
-        self.subprocess_dlg = SubProcessDlg(self)
 
         def run_packaging():
             self.packager.run_packaging_process()
@@ -36,8 +51,6 @@ class MainApp(MainWindow):
 
         self.center_widget.run_packaging_btn.clicked.connect(run_packaging)
         self.packager.subprocess.output.connect(self.subprocess_dlg.handle_output)
-
-        self.status_bar.showMessage("就绪")
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         """
@@ -49,7 +62,8 @@ class MainApp(MainWindow):
         super(MainApp, self).closeEvent(event)
 
 
-app = QApplication(sys.argv)
-window = MainApp()
-window.show()
-sys.exit(app.exec())
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = MainApp()
+    window.show()
+    sys.exit(app.exec())


### PR DESCRIPTION
通过添加 `PackagingTask` 打包任务类，实现了

1. 对用户输入的选项进行即时检查
   - 若用户输入通过检查，则界面对应项才有相应变化（优于原先界面直接响应用户输入的做法）、`Packaging` 类才设置对应参数
   - 若用户输入未通过检查，则弹出警告窗口，并重置界面对应项
2. 将每次打包的参数详情保存到 `PackagingTask` 的实例属性中，为未来实现「将打包任务保存至文件」做基础

-------

注意： `PackagingTask` 类的功能还未完全实现，有待未来继续完善优化。

另：还实现了 `InterpreterValidator` Python 解释器验证器类。